### PR TITLE
应对php7.2.2的最上方通知---反对使用_autoload,使php7.2用户正常使用

### DIFF
--- a/lib/reg.php
+++ b/lib/reg.php
@@ -91,7 +91,7 @@ function class_autoload($c) {
 if (function_exists('spl_autoload_register')) {
 	spl_autoload_register('class_autoload');
 } else {
-	function __autoload($c){
+	function __sql_autoload($c){
 		class_autoload($c);
 	}
 }


### PR DESCRIPTION
应对php7.2.2的最上方通知---反对使用_autoload,使php7.2用户正常使用