### PR TITLE
更换ICP备案链接 

### DIFF
--- a/lib/ui.php
+++ b/lib/ui.php
@@ -43,7 +43,7 @@ function loadfoot($copy = false) {
     if(defined('SYSTEM_NO_UI')) return;
 	$icp=option::get('icp');
 	if (!empty($icp)) {
-		echo ' | <a href="http://www.miitbeian.gov.cn/" target="_blank">'.$icp.'</a>';
+		echo ' | <a href="http://beian.miit.gov.cn/" target="_blank">'.$icp.'</a>';
 	}
 	echo '<br/>'.option::get('footer');
 	doAction('footer');

--- a/templates/login.php
+++ b/templates/login.php
@@ -52,7 +52,7 @@
 	<?php
   $icp=option::get('icp');
     if (!empty($icp)) {
-      echo ' | <a href="http://www.miitbeian.gov.cn/" target="_blank">'.$icp.'</a>';
+      echo ' | <a href="http://beian.miit.gov.cn/" target="_blank">'.$icp.'</a>';
     }
     echo '<br/>'.option::get('footer');
     doAction('footer');

--- a/templates/reg.php
+++ b/templates/reg.php
@@ -76,7 +76,7 @@ if (!empty($yr_reg)) { ?>
 	<?php
 	$icp=option::get('icp');
     if (!empty($icp)) {
-      echo ' | <a href="http://www.miitbeian.gov.cn/" target="_blank">'.$icp.'</a>';
+      echo ' | <a href="http://beian.miit.gov.cn/" target="_blank">'.$icp.'</a>';
     }
     echo '<br/>'.option::get('footer');
     doAction('footer');


### PR DESCRIPTION
工信部调整了ICP备案链接，原地址无法使用。
将链接由http://www.miitbeian.gov.cn/
换为http://beian.miit.gov.cn/