### PR TITLE
fix #96, 支持php8.0以上，增加扫码登录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 setup/install.lock
+plugins/
+!plugins/wmzz_debug

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -224,16 +224,11 @@ function getPluginInfo($plugin) {
 		);
 	}
 	$r['plugin']['id'] = $plugin;
-	if (file_exists($path . $plugin . '_setting.php'))
-		$r['core']['setting'] = true;
-	if (file_exists($path . $plugin . '_show.php'))
-		$r['core']['show'] = true;
-	if (file_exists($path . $plugin . '_vip.php'))
-		$r['core']['vip'] = true;
-	if (file_exists($path . $plugin . '_private.php'))
-		$r['core']['private'] = true;
-	if (file_exists($path . $plugin . '_public.php'))
-		$r['core']['public'] = true;
+    $r['core']['setting'] = file_exists($path . $plugin . '_setting.php');
+    $r['core']['show'] = file_exists($path . $plugin . '_show.php');
+    $r['core']['vip'] = file_exists($path . $plugin . '_vip.php');
+    $r['core']['private'] = file_exists($path . $plugin . '_private.php');
+    $r['core']['public'] = file_exists($path . $plugin . '_public.php');
 	//取插件加载顺序
 	global $m;
 	$q = $m->once_fetch_array('Select `order` From `'.DB_NAME.'`.`'.DB_PREFIX."plugins` Where `name`='{$plugin}' LIMIT 1");

--- a/lib/reg.php
+++ b/lib/reg.php
@@ -14,18 +14,6 @@ $i['db']['prefix'] = DB_PREFIX;
 $i['db']['passwd'] = DB_PASSWD;
 $i['db']['name'] = DB_NAME;
 
-@ini_set('magic_quotes_runtime',0);
-if (get_magic_quotes_gpc()) {
-    function fuck_magic_quotes($value) {
-        $value = is_array($value) ? array_map('fuck_magic_quotes', $value) : stripslashes($value);
-        return $value;
-    }
-    $_POST    = array_map('fuck_magic_quotes', $_POST);
-    $_GET     = array_map('fuck_magic_quotes', $_GET);
-    $_COOKIE  = array_map('fuck_magic_quotes', $_COOKIE);
-    $_REQUEST = array_map('fuck_magic_quotes', $_REQUEST);
-}
-
 //_POST _GET _REQUEST
 $i['post']    = $_POST;
 $i['get']     = $_GET;

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -78,14 +78,34 @@ function textMiddle($text, $left, $right) {
  * 获取一个bduss对应的百度用户名
  *
  * @param string $bduss BDUSS
- * @return string|bool 百度用户名，失败返回FALSE
+ * @return string 百度用户名，失败返回""
  */
-function getBaiduId($bduss){
-	$c = new wcurl('http://i.baidu.com/');
-	$c->addCookie(array('BDUSS' => $bduss,'BAIDUID' => strtoupper(md5(time()))));
-	$data = $c->get();
-	$c->close();
-	return urldecode(textMiddle($data,'main?un=','&fr=ibaidu&ie=utf-8'));
+function getBaiduId(string $bduss){
+    //$c = new wcurl('http://top.baidu.com/user/pass');
+    //$c->addCookie(array('BDUSS' => $bduss));
+    //$data = $c->get();
+    //$c->close();
+	$userData = getBaiduUserInfo($bduss);
+    return isset($userData["name"]) ? $userData["name"] : "";
+}
+
+/**
+ * 获取一个bduss对应的百度用户信息
+ *
+ * @param string $bduss BDUSS
+ * @return array|bool 百度用户信息，失败返回FALSE
+ */
+function getBaiduUserInfo(string $bduss){
+    $c = new wcurl('https://tieba.baidu.com/mg/o/profile?format=json');
+    $c->addCookie(array('BDUSS' => $bduss));
+    $data = $c->get();
+    $c->close();
+    $data = json_decode($data, true);
+	$data = isset($data["data"]["user"]) ? $data["data"]["user"] : false;
+    if ($data) {
+        $data["portrait"] = preg_replace("/\?t=.*/", "", $data["portrait"]);
+    }
+    return $data;
 }
 
 /**

--- a/plugins/wmzz_debug/wmzz_debug.php
+++ b/plugins/wmzz_debug/wmzz_debug.php
@@ -8,7 +8,7 @@
 if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); } 
 
 function wmzz_debug_system1() {
-	$GLOBALS['wmzz_debug_time'] = microtime();
+	$GLOBALS['wmzz_debug_time'] = microtime(true);
 }
 
 addAction('header','wmzz_debug_system1');
@@ -22,7 +22,7 @@ addAction('index_p_3','wmzz_debug_phpinfo');
 
 function wmzz_debug_system2() {
 	global $m;
-	echo '<br/>调试信息：执行 MySQL 查询 '. $m->queryCount . ' 次，PHP 运行耗时 '. round(microtime() - $GLOBALS['wmzz_debug_time'],9) . ' 秒';
+	echo '<br/>调试信息：执行 MySQL 查询 '. $m->queryCount . ' 次，PHP 运行耗时 '. round(microtime(true) - $GLOBALS['wmzz_debug_time'],9) . ' 秒';
 }
 
 addAction('footer','wmzz_debug_system2');

--- a/setting.php
+++ b/setting.php
@@ -580,6 +580,7 @@ switch (SYSTEM_PAGE) {
 
     case 'set':
         // 获取头像的url
+		// 无法获取无id帐号头像, 不建议使用 *wontfix
         if($i['post']['face_img'] == 1 && $i['post']['face_baiduid'] != ''){
             $c = new wcurl('http://www.baidu.com/p/'.$i['post']['face_baiduid']);
             $data = $c->get();

--- a/templates/baiduid.php
+++ b/templates/baiduid.php
@@ -8,7 +8,7 @@ global $m;
 <!-- NAVI -->
 <ul class="nav nav-tabs" id="PageTab">
   <li class="active"><a href="#adminid" data-toggle="tab" onclick="$('#newid2').css('display','none');$('#newid').css('display','none');$('#adminid').css('display','');">管理账号</a></li>
-  <?php if (option::get('bduss_num') != '-1' || ISVIP) { ?><li><a href="#newid" data-toggle="tab" onclick="$('#newid').css('display','');$('#adminid').css('display','none');$('#newid2').css('display','none');">自动绑定</a></li>
+  <?php if (option::get('bduss_num') != '-1' || ISVIP) { ?><li><a href="#newid" data-toggle="tab" onclick="$('#newid').css('display','');$('#adminid').css('display','none');$('#newid2').css('display','none');">扫码绑定</a></li>
   <li><a href="#newid2" data-toggle="tab" onclick="$('#newid2').css('display','');$('#adminid').css('display','none');$('#newid').css('display','none');">手动绑定</a></li><?php } ?>
 </ul>
 <br/>
@@ -33,7 +33,7 @@ global $m;
   <?php if (option::get('bduss_num') != '0' && ISVIP != true) echo '，您最多能够绑定 '.option::get('bduss_num').' 个账号'; ?>
 。</div>
 <?php } if(!empty($i['user']['bduss'])) { ?>
-
+<div class="table-responsive">
 <table class="table table-striped">
   <thead>
     <tr>
@@ -56,6 +56,7 @@ global $m;
    ?>
   </tbody>
 </table>
+</div>
 <?php } ?>
 </div>
 <!-- END PAGE1 -->
@@ -70,31 +71,18 @@ global $m;
               $('.addbdis_text').html('正在拉取验证信息...');
               $('#addbdid_pb').css({"width":"25%"});
               $.ajax({
-                  url:"ajax.php?mod=baiduid:getverify",
+                  url:"ajax.php?mod=baiduid:qrlogin",
                   async:true,
                   dataType:"json",
                   type:'POST',
                   data: {
-                      'bd_name': $('#bd_name').val() ,
-                      'bd_pw': $('#bd_pw').val()
-                  },
-                  beforeSend: function(x) {
-                      this.data += "&vcode=" + $('#bd_v').val() + "&vcodestr=" + $('#vcodeStr').val();
+                      'sign': $('#sign').val() ,
                   },
                   complete: function(x,y) {
                       $('#addbdid_submit').removeAttr('disabled');
                   },
                   success: function(x) {
-                      if(x.error == -3) {
-                          $('#addbdid_pb').css({"width":"70%"});
-                          $('#addbdid_vcodeRequired').attr('value','1');
-                          $('#vcodeImg').attr('src', x.img);
-                          $('#vcodeStr').attr('value', x.vcodestr);
-                          $('#addbdis_text').html(x.msg);
-                          $('#addbdid_msg').html(x.msg);
-                          $('#addbdid_submit').removeAttr('disabled');
-                          $('#addbdid_ver').css({"display":""});
-                      } else if(x.error == 0) {
+                      if(x.error == 0) {
                           $('#addbdid_msg').html('成功绑定百度账号：' + x.name);
                           $('#addbdid_pb').css({"width":"100%"});
                           $('#addbdid_prog').fadeOut(500);
@@ -104,7 +92,7 @@ global $m;
                   },
                   error: function(x) {
                       $('#addbdid_prog').fadeOut(500);
-                      $('#addbdid_msg').html('操作失败，未知错误。这可能是网络原因所致，请重试绑定#2');
+                      $('#addbdid_msg').html('操作失败，未知错误。这可能是网络原因所致，请刷新重试#2');
                   }
               });
           });
@@ -126,43 +114,25 @@ global $m;
   </div>
 </div>
 <a name="#newid"></a>
-<div class="alert alert-warning" role="alert" id="addbdid_msg">如果您多次尝试绑定失败，可能是异地登录保护造成的原因，不妨试试 <a href="https://bduss.tbsign.cn" target="_blank">手动获取</a> 吧！</div>
+<div class="alert alert-warning" role="alert" id="addbdid_msg">如果您多次尝试绑定失败，不妨试试 <a href="https://bduss.nest.moe" target="_blank">手动获取</a> 吧！</div>
 <form method="post" id="addbdid_form" onsubmit="return false;">
-<div class="input-group">
-  <span class="input-group-addon">百度账号</span>
-  <input type="text" class="form-control" id="bd_name" placeholder="你的百度账户名，建议填写邮箱" required>
-</div>
-
-<br/>
-
-<div class="input-group">
-  <span class="input-group-addon">百度密码</span>
-  <input type="password" class="form-control" id="bd_pw" placeholder="你的百度账号密码" required>
-</div>
-<br/>
+  <?php $login_info = misc::get_login_qrcode(); ?>
+  <img src="//<?=$login_info["imgurl"] ?>" alt="qrcode" class="thumbnail center-block">
   <div id="addbdid_ver" style="display: none">
-    <img onclick="addbdid_getcode();" src="" style="float:left;" id="vcodeImg">&nbsp;&nbsp;&nbsp;请在下面输入左图中的字符<br>&nbsp;&nbsp;&nbsp;点击图片更换验证码
-    <br/><br/>
-    <div class="input-group">
-      <span class="input-group-addon">验证码</span>
-       <input type="text" class="form-control" id="bd_v" placeholder="请输入上图的字符" />
-    </div>
-    <br/>
-    <input type="hidden" id="vcodeStr" name="vcodestr" value=""/>
-      <input type="hidden" id="addbdid_vcodeRequired" value="0">
+    <input type="hidden" id="sign" value="<?=$login_info["sign"] ?>">
   </div>
-<input type="submit" id="addbdid_submit" class="btn btn-primary" value="点击绑定">
+  <a href="https://wappass.baidu.com/wp/?qrlogin=&sign=<?=$login_info["sign"] ?>" class="btn btn-default btn-block" target="_blank">网页授权</a>
+  <input type="submit" id="addbdid_submit" class="btn btn-primary btn-block" value="点击绑定">
 </form>
 <br/><br/>
 <div class="panel panel-default">
-	<div class="panel-heading" onclick="$('#win_bduss').fadeToggle();"><h3 class="panel-title"><span class="glyphicon glyphicon-chevron-down"></span> 关于提示登陆不成功的解决办法</h3></div>
-	<div class="panel-body" id="win_bduss">
-	    1.<b>登录不成功主要是因为您尝试登录的帐号开启了异地登陆保护！</b>
-	    <br/><br/>2.所以我们试着关闭它，地址:<a href="https://passport.baidu.com/v2/accountsecurity" target="_blank">点击进入百度安全中心</a> （未登录百度请先登录再打开此链接）
-	    <br/><br/>3.此时可以看到 <b>登录保护：未开通</b> 然后我们点击后面的开通，然后选择 <b>每次主动登录时需要验证安全中心手机版、短信或邮件验证码，三者任选其一</b> 然后点击确定提示验证，验证后提示设置成功。
-        <br/><br/>4.然后返回 <a href="https://passport.baidu.com/v2/accountsecurity" target="_blank">百度安全中心</a> 可以看到 <b>登录保护：登录即启动保护</b> 然后我们点后面的 <b>修改</b> 。
-        <br/><br/>5.最后，我们可以看到一个之前看不到的选项 <b>关闭登录保护</b> 选择它确定，直到提示成功后，然后再次在上面自动绑定处尝试进行登录，登陆成功后刷新贴吧列表即可！
-	</div>
+    <div class="panel-heading" onclick="$('#win_bduss').fadeToggle();"><h3 class="panel-title"><span class="glyphicon glyphicon-chevron-down"></span> 提示</h3></div>
+    <div class="panel-body" id="win_bduss">
+    <ul>
+      <li>可直接点击 "网页授权" 并在新打开页授权，无需客户端扫码，非移动设备的UA可能会导致无法打开</li>
+      <li>若二维码失效请刷新本页以刷新二维码</li>
+    </ul>
+    </div>
 </div>
 </div>
 
@@ -181,17 +151,17 @@ global $m;
 
 <br/><br/><b>以下是贴吧账号手动绑定教程：</b><br/><br/>
 <div class="panel panel-default">
-	<div class="panel-heading" onclick="$('#chrome_bduss').fadeToggle();"><h3 class="panel-title"><span class="glyphicon glyphicon-chevron-down"></span> 点击查看在 Chrome 浏览器下的绑定方法</h3></div>
-	<div class="panel-body" id="chrome_bduss" style="display:none">
-	    1.使用 Chrome 或 Chromium 内核的浏览器
-		<br/><br/>2.打开百度首页 <a href="http://www.baidu.com" target="_blank">http://www.baidu.com/</a>
-   	    <br/><br/>3.右键，点击 <b>查看网页信息</b>
-		<br/><br/>4.确保已经登录百度，然后点击 <b>显示 Cookie 和网站数据</b>
-		<br/><br/>5.如图，依次展开 <b>passport.baidu.com</b> -> <b>Cookie</b> -> <b>BDUSS</b>
-		<br/><br/><a href="source/doc/baiduid.png" target="_blank"><img src="source/doc/baiduid.png"></a>
-		<br/><br/>6.按下 Ctrl+A 全选，然后复制并输入到上面的表单即可
+    <div class="panel-heading" onclick="$('#chrome_bduss').fadeToggle();"><h3 class="panel-title"><span class="glyphicon glyphicon-chevron-down"></span> 点击查看在 Chrome 浏览器下的绑定方法</h3></div>
+    <div class="panel-body" id="chrome_bduss" style="display:none">
+        1.使用 Chrome 或 Chromium 内核的浏览器
+        <br/><br/>2.打开百度首页 <a href="http://www.baidu.com" target="_blank">http://www.baidu.com/</a>
+           <br/><br/>3.右键，点击 <b>查看网页信息</b>
+        <br/><br/>4.确保已经登录百度，然后点击 <b>显示 Cookie 和网站数据</b>
+        <br/><br/>5.如图，依次展开 <b>passport.baidu.com</b> -> <b>Cookie</b> -> <b>BDUSS</b>
+        <br/><br/><a href="source/doc/baiduid.png" target="_blank"><img src="source/doc/baiduid.png"></a>
+        <br/><br/>6.按下 Ctrl+A 全选，然后复制并输入到上面的表单即可
     <br/><br/>请注意，一旦退出登录，可能导致 BDUSS 失效，因此建议在隐身模式下登录
-	</div>
+    </div>
 </div>
 </div>
 <!-- END PAGE3 -->


### PR DESCRIPTION
修复: 百度id获取方式以修复 '您的 BDUSS Cookie 信息有误'，位于 sfc.functions.php L77
修复: 使用 microtime(true) 替代 microtime() 解决字符串相减无法进行的问题，位于 wmzz_debug.php
修复: 插件系统功能的判断，位于 plugins.php L227
移除: 所有魔术引号相关函数 get_magic_quotes_gpc() 以支援 php8
移除: 直接登录百度账号
更新: 获取关注列表接口，位于 class.misc.php L526
添加: 扫码登录百度账号