### PR TITLE
修复: 不支持php7以下php版本  fix111 fix113

### DIFF
--- a/lib/class.misc.php
+++ b/lib/class.misc.php
@@ -523,7 +523,7 @@ class misc {
 		return $rt;
 	}
 
-	public static function getTieba2(string $bduss, int $pn = 1): string{
+	public static function getTieba2($bduss, $pn = 1) {
         $tl = new wcurl("https://tieba.baidu.com/mg/o/getForumHome?st=0&pn={$pn}&rn=200",['User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36']);
         $tl->addCookie(array('BDUSS' => $bduss));
         return $tl->get();
@@ -593,7 +593,7 @@ class misc {
 	/**
      * 获得二维码及sign
      */
-    public static function get_login_qrcode() :array {
+    public static function get_login_qrcode() {
         $resp = ["sign" => null, "imgurl" => null];
         $get_qrcode = json_decode((new wcurl("https://passport.baidu.com/v2/api/getqrcode?lp=pc"))->get(), true);
         if(isset($get_qrcode["imgurl"]) && isset($get_qrcode["sign"])){
@@ -601,7 +601,7 @@ class misc {
         }
         return $resp;
     }
-    public static function get_real_bduss(string $sign) :array{
+    public static function get_real_bduss($sign) {
         //status code
         //errno不等于0或1时需要要求更换二维码及sign
         //-1 更换二维码

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -80,7 +80,7 @@ function textMiddle($text, $left, $right) {
  * @param string $bduss BDUSS
  * @return string 百度用户名，失败返回""
  */
-function getBaiduId(string $bduss){
+function getBaiduId($bduss){
     //$c = new wcurl('http://top.baidu.com/user/pass');
     //$c->addCookie(array('BDUSS' => $bduss));
     //$data = $c->get();
@@ -95,7 +95,7 @@ function getBaiduId(string $bduss){
  * @param string $bduss BDUSS
  * @return array|bool 百度用户信息，失败返回FALSE
  */
-function getBaiduUserInfo(string $bduss){
+function getBaiduUserInfo($bduss){
     $c = new wcurl('https://tieba.baidu.com/mg/o/profile?format=json');
     $c->addCookie(array('BDUSS' => $bduss));
     $data = $c->get();
@@ -1003,6 +1003,6 @@ function csrf($strict = true) {
 		$p = parse_url($_SERVER['HTTP_REFERER']);
 		$parse_system_url = parse_url(isset($i["opt"]["system_url"]) ? $i["opt"]["system_url"] : "");
 		if(!$p || empty($p['host'])) msg('CSRF防御：无效请求。<a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">了解更多关于CSRF防御...</a>');
-		if($p['host'] != ($parse_system_url['host'] ? $parse_system_url['host'] : '')) msg('CSRF防御：错误的请求来源<a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">了解更多关于CSRF防御...</a>');
+		if($p['host'] != (isset($parse_system_url['host']) ? $parse_system_url['host'] : '')) msg('CSRF防御：错误的请求来源<a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">了解更多关于CSRF防御...</a>');
 	}
 }


### PR DESCRIPTION
- 移除[标量类型声明](https://www.php.net/manual/zh/migration70.new-features.php#migration70.new-features.scalar-type-declarations)
- 移除[返回值类型声明](https://www.php.net/manual/zh/migration70.new-features.php#migration70.new-features.return-type-declarations) fix111 fix113 
- 修复遗漏的 `isset()` 函数，位于 `sfc.functions.php L1006`