### PR TITLE
修复在PHP81环境中的warning

### DIFF
--- a/lib/reg.php
+++ b/lib/reg.php
@@ -31,7 +31,7 @@ while ($rsr = $m->fetch_array($rs)) {
 
 //贴吧分表列表
 $i['tabpart'] = $i['table'] = unserialize($i['opt']['fb_tables']);
-$i['table'][] = 'tieba'; //贴吧表列表
+$i['table'] = ['tieba']; //贴吧表列表
 
 //当前页面/模式, $i['mode'][0] 一般表示页面
 if (!empty($_REQUEST['mod'])) {


### PR DESCRIPTION
修复在PHP81中warning：Deprecated: Automatic conversion of false to array is deprecated in /lib/reg.php on line 34