### PR TITLE
fix docker supported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/s390x
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,14 @@ ENV LANG=zh_CN.UTF-8 \
     TZ=Asia/Shanghai \
     WORKDIR=/var/www \
     PS1="\u@\h:\w \$ "
-    
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-nobin.tar.gz /tmp/
-RUN apk add --no-cache curl tar \
-    && curl -sSL "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar -xzf - -C / \
+
+RUN apk add --no-cache curl tar xz \
+    && curl -L -o /tmp/s6-overlay-symlinks-noarch.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v3.1.0.1/s6-overlay-symlinks-noarch.tar.xz" \
+    && tar -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz -C / \
+    && curl -L -o /tmp/s6-overlay-noarch.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v3.1.0.1/s6-overlay-noarch.tar.xz" \
+    && tar -Jxpf /tmp/s6-overlay-noarch.tar.xz -C / \
+    && curl -L -o /tmp/s6-overlay.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v3.1.0.1/s6-overlay-$(uname -m | sed s/amd64/x86_64/ | sed s/armv7l/armhf/ ).tar.xz" \
+    && tar -Jxpf /tmp/s6-overlay.tar.xz -C / \
     && apk add --no-cache --update \
        bash \
        git \
@@ -27,14 +31,15 @@ RUN apk add --no-cache curl tar \
     && echo -e "${TZ}" > /etc/timezone \
     && echo -e "max_execution_time = 3600\nupload_max_filesize=128M\npost_max_size=128M\nmemory_limit=1024M\ndate.timezone=${TZ}" > /etc/php7/conf.d/99-overrides.ini \
     && echo -e "[global]\nerror_log = /dev/stdout\ndaemonize = no\ninclude=/etc/php7/php-fpm.d/*.conf" > /etc/php7/php-fpm.conf \
-    && echo -e "[www]\nuser = caddy\ngroup = caddy\nlisten = 127.0.0.1:9000\nlisten.owner = caddy\nlisten.group = caddy\npm = ondemand\npm.max_children = 75\npm.max_requests = 500\npm.process_idle_timeout = 10s\nchdir = $WORKDIR" > /etc/php7/php-fpm.d/www.conf \
-    && echo -e ":8080\nroot * $WORKDIR\nlog {\n    level warn\n}\nphp_fastcgi 127.0.0.1:9000\nfile_server" > /etc/caddy/Caddyfile \
+    && echo -e "[www]\nuser = caddy\ngroup = caddy\nlisten = 127.0.0.1:9000\nlisten.owner = caddy\nlisten.group = caddy\npm = ondemand\npm.max_children = 75\npm.max_requests = 500\npm.process_idle_timeout = 10s\nchdir = /var/www" > /etc/php7/php-fpm.d/www.conf \
+    && echo -e ":8080\nroot * /var/www\nlog {\n    level warn\n}\nphp_fastcgi 127.0.0.1:9000\nfile_server" > /etc/caddy/Caddyfile \
     && rm -rf \
-       $WORKDIR/* \
+       /var/www/* \
        /var/cache/apk/* \
        /tmp/* \
-    && git clone --depth=1 -b master https://github.com/MoeNetwork/Tieba-Cloud-Sign $WORKDIR \
-    && cp -r $WORKDIR/docker/s6-overlay/etc/cont-init.d/* /etc/cont-init.d \
-    && cp -r $WORKDIR/docker/s6-overlay/etc/services.d/* /etc/services.d
-WORKDIR $WORKDIR
+    && git clone --depth=1 -b master https://github.com/MoeNetwork/Tieba-Cloud-Sign /var/www \
+    && mkdir /etc/cont-init.d \
+    && mkdir /etc/services.d \
+    && cp -r /var/www/docker/s6-overlay/etc/* /etc/
+
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
update: s6-overlay version to `3.1.0.1`
remove: unsupported platform `i386`, `armv6`, `ppc64le`