### PR TITLE
[v4.97] 使用 portrait 替代用户名

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -226,10 +226,11 @@ switch (SYSTEM_PAGE) {
 		$loginResult = misc::get_real_bduss($sign);
 		if($loginResult["error"] == 0) {
 			$baiduUserInfo = getBaiduUserInfo($loginResult["bduss"]);
-			if (!empty($baiduUserInfo["name"])) {
+			if (!empty($baiduUserInfo["portrait"])) {
 				$baidu_name = $baiduUserInfo["name"];
+				$baidu_name_portrait = sqladds($baiduUserInfo["portrait"]);
 				if((option::get('same_pid') == '1' || option::get('same_pid') == '2') && !ISADMIN) {
-					$checkSame = $m->once_fetch_array("SELECT * FROM `".DB_NAME."`.`".DB_PREFIX."baiduid` WHERE `name` = '{$baidu_name}'");
+					$checkSame = $m->once_fetch_array("SELECT * FROM `".DB_NAME."`.`".DB_PREFIX."baiduid` WHERE `portrait` = '{$baidu_name_portrait}'");
 					if(!empty($checkSame)) {
 						if(option::get('same_pid') == '2') {
 							$loginResult["error"] = -11;
@@ -240,14 +241,14 @@ switch (SYSTEM_PAGE) {
 						}
 						$loginResult["bduss"] = "";
 					} else {
-						$m->query("INSERT INTO `" . DB_NAME . "`.`" . DB_PREFIX . "baiduid` (`id`,`uid`,`bduss`,`name`) VALUES  (NULL,'" . UID . "', '{$loginResult["bduss"]}', '{$baidu_name}')");
+						$m->query("INSERT INTO `" . DB_NAME . "`.`" . DB_PREFIX . "baiduid` (`id`,`uid`,`bduss`,`name`,`portrait`) VALUES  (NULL,'" . UID . "', '{$loginResult["bduss"]}', '{$baidu_name}', '{$baidu_name_portrait}')");
 						$loginResult["msg"] = "获取BDUSS成功";
-						$loginResult["name"] = $baidu_name;
+						$loginResult["name"] = "{$baidu_name} [{$baidu_name_portrait}]";
 					}
 				} else {
-					$m->query("INSERT INTO `" . DB_NAME . "`.`" . DB_PREFIX . "baiduid` (`id`,`uid`,`bduss`,`name`) VALUES  (NULL,'" . UID . "', '{$loginResult["bduss"]}', '{$baidu_name}')");
+					$m->query("INSERT INTO `" . DB_NAME . "`.`" . DB_PREFIX . "baiduid` (`id`,`uid`,`bduss`,`name`,`portrait`) VALUES  (NULL,'" . UID . "', '{$loginResult["bduss"]}', '{$baidu_name}', '{$baidu_name_portrait}')");
 					$loginResult["msg"] = "获取BDUSS成功";
-					$loginResult["name"] = $baidu_name;
+					$loginResult["name"] = "{$baidu_name} [{$baidu_name_portrait}]";
 				}
 			}
 		}

--- a/init.php
+++ b/init.php
@@ -5,7 +5,7 @@
  */
 
 define('SYSTEM_FN','百度贴吧云签到');
-define('SYSTEM_VER','4.96');
+define('SYSTEM_VER','4.97');
 define('SYSTEM_VER_NOTE','');
 define('SYSTEM_ROOT',dirname(__FILE__));
 define('PLUGIN_ROOT',dirname(__FILE__) . '/plugins/');

--- a/lib/class.misc.php
+++ b/lib/class.misc.php
@@ -153,7 +153,7 @@ class misc {
 	 */
 
 	public static function getTbs($uid,$bduss){
-		$ch = new wcurl('http://tieba.baidu.com/dc/common/tbs', array('User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1','Referer: http://tieba.baidu.com/','X-Forwarded-For: ' . mt_rand(0,255) . '.' . mt_rand(0,255) . '.' . mt_rand(0,255) . '.' . mt_rand(0,255)));
+		$ch = new wcurl('http://tieba.baidu.com/dc/common/tbs');
 		$ch->addcookie("BDUSS=". $bduss);
 		$x = json_decode($ch->exec(),true);
 		return $x['tbs'];
@@ -163,13 +163,12 @@ class misc {
      * 对输入的数组添加客户端验证代码（tiebaclient!!!）
      * @param array $data 数组
      */
-    public static function addTiebaSign(&$data) {
-        $data = array(
-            '_client_id' => '03-00-DA-59-05-00-72-96-06-00-01-00-04-00-4C-43-01-00-34-F4-02-00-BC-25-09-00-4E-36',
-            '_client_type' => '4',
-            '_client_version' => '6.0.1',
-            '_phone_imei' => '540b43b59d21b7a4824e1fd31b08e9a6',
-        ) + $data;
+    public static function addTiebaSign(&$data, $withClientType = true) {
+        $data["_client_version"] = "12.22.1.0";
+		if ($withClientType) {
+			$data["_client_type"] = "4";
+		}
+		ksort($data);
         $x = '';
         foreach($data as $k=>$v) {
             $x .= $k.'='.$v;
@@ -199,14 +198,8 @@ class misc {
 		));	
 		$ch->addcookie(array('BDUSS' => $ck));
 		$temp = array(
-			'BDUSS' => misc::getCookie($pid),
-			'_client_id' => '03-00-DA-59-05-00-72-96-06-00-01-00-04-00-4C-43-01-00-34-F4-02-00-BC-25-09-00-4E-36',
-			'_client_type' => '4',
-			'_client_version' => '1.2.1.17',
-			'_phone_imei' => '540b43b59d21b7a4824e1fd31b08e9a6',
 			'fid' => $fid,
 			'kw' => $kw,
-			'net_type' => '3',
 			'tbs' => misc::getTbs($uid,$ck)
 		);
         self::addTiebaSign($temp);
@@ -260,24 +253,15 @@ class misc {
 	 * 客户端签到
 	 */
 	public static function DoSign_Client($uid,$kw,$id,$pid,$fid,$ck){
-		$ch = new wcurl('http://c.tieba.baidu.com/c/c/forum/sign', array('Content-Type: application/x-www-form-urlencoded','User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1'));
+		$ch = new wcurl('http://c.tieba.baidu.com/c/c/forum/sign');
 		$ch->addcookie("BDUSS=".$ck);
 		$temp = array(
 			'BDUSS' => misc::getCookie($pid),
-			'_client_id' => '03-00-DA-59-05-00-72-96-06-00-01-00-04-00-4C-43-01-00-34-F4-02-00-BC-25-09-00-4E-36',
-			'_client_type' => '4',
-			'_client_version' => '1.2.1.17',
-			'_phone_imei' => '540b43b59d21b7a4824e1fd31b08e9a6',
 			'fid' => $fid,
 			'kw' => $kw,
-			'net_type' => '3',
 			'tbs' => misc::getTbs($uid,$ck)
 		);
-		$x = '';
-		foreach($temp as $k=>$v) {
-			$x .= $k.'='.$v;
-		}
-		$temp['sign'] = strtoupper(md5($x.'tiebaclient!!!'));
+		self::addTiebaSign($temp);
 		return $ch->post($temp);
 	}
 
@@ -484,14 +468,31 @@ class misc {
 	 */
 	public static function getUserid($pid){
 		global $m;
-		$ub  = $m->once_fetch_array("SELECT * FROM `".DB_PREFIX."baiduid` WHERE `id` = '{$pid}';");
-		$user = new wcurl("http://tieba.baidu.com/home/get/panel?ie=utf-8&un={$ub['name']}");
+		$ub  = $m->once_fetch_array("SELECT portrait FROM `".DB_PREFIX."baiduid` WHERE `id` = '{$pid}';");
+		return self::getUseridByPortrait($ub['portrait']);
+	}
+	/*
+	 * 获取指定portrait的userid
+	 */
+	public static function getUseridByPortrait($portrait){
+		$user = new wcurl("https://tieba.baidu.com/home/get/panel?ie=utf-8&id={$portrait}");
 		$re = $user->get();
 		$ur = json_decode($re,true);
-		$userid = $ur['data']['id'];
+		$userid = (isset($ur["no"]) && $ur["no"] === 0) ? $ur['data']['id'] : 0;
 		return $userid;
 	}
-
+	/*
+	 * uid转旧版portrait
+	 */
+	public static function uid2LegacyPortrait ($uid) {
+		//貌似对uid较大的新账号没啥效果?
+		$stric = str_pad(dechex(trim($uid)), 8, 0, STR_PAD_LEFT);
+		$sc = '';
+		for ($i = 6; $i >= 0; $i -=2) {
+			$sc .= substr($stric, $i, 2);
+		}
+		return $sc;
+	}
 	/*
 	 * 获取指定pid
 	 */
@@ -502,15 +503,11 @@ class misc {
 		$tl = new wcurl('http://c.tieba.baidu.com/c/f/forum/like',$head);
 		$data = array(
 			'BDUSS' => $bduss,
-			'_client_version' => '12.22.1.0',
 			'friend_uid' => $userid,
 			'page_no' => $pn,
 			'page_size' => 200,
 		);
-		$sign_str = '';
-		foreach($data as $k=>$v) $sign_str .= $k.'='.$v;
-		$sign = strtoupper(md5($sign_str.'tiebaclient!!!'));
-		$data['sign'] = $sign;
+		self::addTiebaSign($data, false);
 		$tl->addCookie(array('BDUSS' => $bduss));
 		$tl->set(CURLOPT_RETURNTRANSFER,true);
 		$rt = $tl->post($data);
@@ -557,7 +554,7 @@ class misc {
 					$m->query("INSERT INTO `".DB_NAME."`.`".DB_PREFIX.$table."` (`pid`,`fid`, `uid`, `tieba`) VALUES ({$pid},'{$v['id']}', {$uid}, '{$vn}');");
 				}
 			}
-			if ($rc["has_more"] === "0") break;
+			if (!isset($rc["has_more"]) || $rc["has_more"] === "0") break;
 			$pn ++;
 		}
 	}

--- a/lib/class.misc.php
+++ b/lib/class.misc.php
@@ -475,9 +475,7 @@ class misc {
 	 * 获取指定portrait的userid
 	 */
 	public static function getUseridByPortrait($portrait){
-		$user = new wcurl("https://tieba.baidu.com/home/get/panel?ie=utf-8&id={$portrait}");
-		$re = $user->get();
-		$ur = json_decode($re,true);
+		$ur = getUserInfo($portrait, false);
 		$userid = (isset($ur["no"]) && $ur["no"] === 0) ? $ur['data']['id'] : 0;
 		return $userid;
 	}

--- a/lib/class.smtp.php
+++ b/lib/class.smtp.php
@@ -26,7 +26,9 @@ class SMTP {
         $this ->debug = false;
         $this ->smtp_port = $smtp_port;
         $this ->secure = $secure;
-        if ($secure == 'ssl') $relay_host = 'ssl://' . $relay_host;
+        if ($secure == 'ssl') {
+            $relay_host = 'ssl://' . $relay_host;
+        }
         $this ->relay_host = $relay_host;
         $this ->time_out = 30;
         $this ->auth = $auth;

--- a/lib/class.wcurl.php
+++ b/lib/class.wcurl.php
@@ -303,7 +303,7 @@ class wcurl {
      * @param array  $head
      * @return $this
      */
-    public function init($file = '', array $head = array('User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36')) {
+    public function init($file = '', array $head = array('User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36')) {
         $this->reset();
         if(!empty($file)) $this->setUrl($file);
         $this->setHeader($head)->setAll(array(//wcurl默认设定

--- a/lib/globals.php
+++ b/lib/globals.php
@@ -64,7 +64,8 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
 			while ($bd = $m->fetch_array($bds)) {
 				$bdspid = $bd['id'];
 				$i['user']['bduss'][$bdspid] = $bd['bduss'];
-				$i['user']['baidu'][$bdspid] = $bd['name'] ;
+				$i['user']['baidu'][$bdspid] = $bd['name'];
+				$i['user']['baidu_portrait'][$bdspid] = $bd['portrait'];
 			}
 			$optss = $m->query("SELECT * FROM  `".DB_NAME."`.`".DB_PREFIX."users_options` WHERE uid = ".UID);
 			//$GLOBALS = $i['user'];

--- a/lib/msg.php
+++ b/lib/msg.php
@@ -148,7 +148,7 @@ function msg($msg = '未知的异常',$url = true,$die = true,$title = true,$iss
         <?php
 		if ($title) echo '<h3>'.$sysname.' - 提示信息</h3><br/>';
         echo $msg;
-		if ($issue) echo '<br/><a style="float:left" href="http://github.com/MoeNetwork/Tieba-Cloud-Sign/issues" target="_blank">反馈该问题</a><br/>';
+		if ($issue) echo '<br/><a style="float:left" href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/issues" target="_blank">反馈该问题</a><br/>';
 		if ($url !== false) {
             if ($url === true) {
                 echo '<br/><a style="float:right" href="javascript:history.back(-1)"><< 返回上一页</a>';

--- a/lib/reg.php
+++ b/lib/reg.php
@@ -1,5 +1,6 @@
 <?php
 if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); } 
+global $m;
 /**
  * 环境准备
  */

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -108,6 +108,19 @@ function getBaiduUserInfo($bduss){
 }
 
 /**
+ * 获取指定 portrait/baiduid 的用户信息
+ * 
+ * @param string $id portrait/baiduid
+ * @param bool $isBaiduId $id是否为百度id
+ * @return array 用户信息
+ */
+function getUserInfo($id, $isBaiduId = true){
+	$user = new wcurl("https://tieba.baidu.com/home/get/panel?ie=utf-8&" . ($isBaiduId ? "un={$id}" : "id={$id}"));
+	$re = $user->get();
+	return json_decode($re,true);
+}
+
+/**
  * 获取指定邮箱的的Gravatar头像
  * http://en.gravatar.com/site/implement/images/
  * @return bool|string

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -98,12 +98,8 @@ function getBaiduId($bduss){
 function getBaiduUserInfo($bduss){
     $c = new wcurl('http://c.tieba.baidu.com/c/s/login');
     $c->addCookie(array('BDUSS' => $bduss));
-    $temp = array('_client_version' => '12.22.1.0', 'bdusstoken' => $bduss);
-    $x = '';
-    foreach($temp as $k=>$v) {
-        $x .= $k.'='.$v;
-    }
-    $temp['sign'] = strtoupper(md5($x.'tiebaclient!!!'));
+    $temp = array('bdusstoken' => $bduss);
+    misc::addTiebaSign($temp);
     $data = $c->post($temp);
     $c->close();
     $data = json_decode($data, true);
@@ -135,7 +131,7 @@ function getGravatar($s = 140, $d = 'mm', $g = 'g', $site = 'secure') {
 		if(option::uget('face_url') != ''){
 			return option::uget('face_url');
 		} else {
-			return '//tb.himg.baidu.com/sys/portrait/item/';
+			return 'https://himg.bdimg.com/sys/portrait/item/0';
 		}
 	} else {
 		return gravatar(EMAIL, $s, $d, $g, $site);

--- a/setting.php
+++ b/setting.php
@@ -587,10 +587,8 @@ switch (SYSTEM_PAGE) {
         // 获取头像的url
 		// 无法获取无id帐号头像, 不建议使用 *wontfix
         if($i['post']['face_img'] == 1 && $i['post']['face_baiduid'] != ''){
-            $c = new wcurl('http://www.baidu.com/p/'.$i['post']['face_baiduid']);
-            $data = $c->get();
-            $c->close();
-            $i['post']['face_url'] = str_replace('http://', 'https://', trim(stripslashes(textMiddle($data,'<img class=portrait-img src=\x22','\x22>'))));
+			$data = getUserInfo($i['post']['face_baiduid']);
+            $i['post']['face_url'] = "https://himg.bdimg.com/sys/portrait/item/{$data["data"]["portrait"]}";
             if(empty($i['post']['face_url'])) msg('获取贴吧头像失败，可能是网络问题，请重试');
         }
         /*

--- a/setting.php
+++ b/setting.php
@@ -486,12 +486,15 @@ switch (SYSTEM_PAGE) {
 			$bduss = str_ireplace('BDUSS=', '', $bduss);
 			$bduss = str_replace(' ', '', $bduss);
 			$bduss = sqladds($bduss);
-			$baidu_name = sqladds(getBaiduId($bduss));
-			if (empty($baidu_name)) {
+			//get user info
+			$baiduUserInfo = getBaiduUserInfo($bduss);
+			if (empty($baiduUserInfo["portrait"])) {
 				msg('您的 BDUSS Cookie 信息有误，请核验后重新绑定');
 			}
+			$baidu_name = sqladds($baiduUserInfo["name"]);
+			$baidu_name_portrait = sqladds($baiduUserInfo["portrait"]);
 			doAction('baiduid_set_2');
-			$m->query("INSERT INTO `".DB_NAME."`.`".DB_PREFIX."baiduid` (`uid`,`bduss`,`name`) VALUES  (".UID.", '{$bduss}', '{$baidu_name}')");
+			$m->query("INSERT INTO `".DB_NAME."`.`".DB_PREFIX."baiduid` (`uid`,`bduss`,`name`,`portrait`) VALUES  (".UID.", '{$bduss}', '{$baidu_name}', '{$baidu_name_portrait}')");
 		}
 		elseif (!empty($_GET['del'])) {
 			$del = (int) $_GET['del'];
@@ -499,6 +502,8 @@ switch (SYSTEM_PAGE) {
 			$x=$m->once_fetch_array("SELECT * FROM  `".DB_NAME."`.`".DB_PREFIX."users` WHERE  `id` = ".UID." LIMIT 1");
 			$m->query("DELETE FROM `".DB_NAME."`.`".DB_PREFIX."baiduid` WHERE `".DB_PREFIX."baiduid`.`uid` = ".UID." AND `".DB_PREFIX."baiduid`.`id` = " . $del);
 			$m->query('DELETE FROM `'.DB_NAME.'`.`'.DB_PREFIX.$x['t'].'` WHERE `'.DB_PREFIX.$x['t'].'`.`uid` = '.UID.' AND `'.DB_PREFIX.$x['t'].'`.`pid` = '.$del);
+		} elseif (empty($_GET["bduss"])) {
+			msg('BDUSS为空，请核验后重新绑定');
 		}
 		/*
 		elseif (!empty($_GET['reget'])){

--- a/setup/check.php
+++ b/setup/check.php
@@ -72,10 +72,10 @@ function checkclass($f,$m = false) {
 	</thead>
 	<tbody>
 		<tr>
-			<td><a href="http://php.net/" target="_blank">PHP 5+</a></td>
+		<td><a href="http://php.net/" target="_blank">PHP 5+</a></td>
 			<td>必须</td>
 			<td><?php echo phpversion(); ?></td>
-			<td>核心，未来云签到可能不支持 PHP 5.3 以下版本</td>
+			<td>核心，未来云签到将不支持 PHP 7.4 以下版本，请尽快升级</td>
 		</tr>
 		<tr>
 			<td><a href="http://php.net/manual/zh/book.curl.php" target="_blank">Client URL</a></td>
@@ -111,7 +111,7 @@ function checkclass($f,$m = false) {
 			<td><a href="http://php.net/manual/zh/class.mysqli.php" target="_blank">MySQLi</a></td>
 			<td>推荐</td>
 			<td><?php echo checkclass('mysqli'); ?></td>
-			<td>数据库操作，若支持本项可忽略不支持 MySQL 函数</td>
+			<td>数据库操作，若支持本项可忽略不支持 MySQL 函数，使用 Mysql8.0 以上的用户可能需要阅读 <a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/issues/105" target="_blank">issue</a> </td>
 		</tr>
 		<tr>
 			<td><a href="http://www.php.net/manual/zh/function.file-put-contents.php" target="_blank">写入文件</a></td>

--- a/setup/install.php
+++ b/setup/install.php
@@ -83,7 +83,7 @@ define(\'DB_PREFIX\',\'tc_\');
 
 ///////////////////////////////////////其他设置///////////////////////////////////////
 //停用CSRF防御
-//说明在 http://github.com/MoeNetwork/Tieba-Cloud-Sign/wikis/关于云签到CSRF防御
+//说明在 https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1
 define(\'ANTI_CSRF\',true);
 
 //加密用盐，留空为不使用
@@ -229,7 +229,7 @@ define(\'DB_PREFIX\',\''.DB_PREFIX.'\');
 
 ///////////////////////////////////////其他设置///////////////////////////////////////
 //停用CSRF防御
-//说明在 http://github.com/MoeNetwork/Tieba-Cloud-Sign/wikis/关于云签到CSRF防御
+//说明在 https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1
 define(\'ANTI_CSRF\',true);
 
 //加密用盐，留空为不使用

--- a/setup/install.template.sql
+++ b/setup/install.template.sql
@@ -5,11 +5,12 @@ CREATE TABLE `{VAR-PREFIX}baiduid` (
   `id` int(30) unsigned NOT NULL AUTO_INCREMENT,
   `uid` int(30) unsigned NOT NULL,
   `bduss` text NOT NULL,
-  `name` varchar(40) DEFAULT '' NOT NULL,
+  `name` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT '' NOT NULL,
+  `portrait` varchar(40) COLLATE utf8mb4_general_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `uid` (`uid`) USING BTREE,
-  KEY `name` (`name`) USING BTREE
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+  KEY `portrait` (`portrait`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 
 DROP TABLE IF EXISTS `{VAR-PREFIX}cron`;
@@ -86,7 +87,7 @@ INSERT INTO `{VAR-PREFIX}options` VALUES ('cron_sign_again', 'a:2:{s:3:\"num\";i
 INSERT INTO `{VAR-PREFIX}options` VALUES ('sign_hour', '0');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('mail_secure', 'none');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('freetable', 'tieba');
-INSERT INTO `{VAR-PREFIX}options` VALUES ('core_version', '4.7');
+INSERT INTO `{VAR-PREFIX}options` VALUES ('core_version', '4.97');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('vid', '10000');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('update_server', '0');
 #INSERT INTO `{VAR-PREFIX}options` VALUES ('toolpw', '{VAR-TOOLPW}');

--- a/setup/install.template.sql
+++ b/setup/install.template.sql
@@ -6,7 +6,7 @@ CREATE TABLE `{VAR-PREFIX}baiduid` (
   `uid` int(30) unsigned NOT NULL,
   `bduss` text NOT NULL,
   `name` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT '' NOT NULL,
-  `portrait` varchar(40) COLLATE utf8mb4_general_ci NOT NULL,
+  `portrait` varchar(40) COLLATE utf8mb4_general_ci DEFAULT '' NOT NULL,
   PRIMARY KEY (`id`),
   KEY `uid` (`uid`) USING BTREE,
   KEY `portrait` (`portrait`) USING BTREE

--- a/setup/update4.96to4.97.php
+++ b/setup/update4.96to4.97.php
@@ -12,7 +12,7 @@ if (!empty($cv) && $cv >= '4.97') {
 $m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;", true);
 $m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` DROP INDEX `name`;", true);
 $m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` CHANGE `name` `name` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '';", true);
-$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` ADD `portrait` VARCHAR(40) NOT NULL AFTER `name`;", true);
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` ADD `portrait` VARCHAR(40) DEFAULT '' NOT NULL AFTER `name`;", true);
 $m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` ADD INDEX(`portrait`);", true);
 
 //update name_show and portrait

--- a/setup/update4.96to4.97.php
+++ b/setup/update4.96to4.97.php
@@ -1,0 +1,31 @@
+<?php
+define('SYSTEM_DEV', true);
+define('SYSTEM_NO_CHECK_VER', true);
+define('SYSTEM_NO_CHECK_LOGIN', true);
+define('SYSTEM_NO_PLUGIN', true);
+include __DIR__ . '/../init.php';
+global $m,$i;
+$cv = option::get('core_version');
+if (!empty($cv) && $cv >= '4.97') {
+	msg('您的云签到已升级到 V4.97 版本，请勿重复更新<br/><br/>请立即删除 /setup/update4.96to4.97.php');
+}
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;", true);
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` DROP INDEX `name`;", true);
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` CHANGE `name` `name` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '';", true);
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` ADD `portrait` VARCHAR(40) NOT NULL AFTER `name`;", true);
+$m->query("ALTER TABLE `" . DB_PREFIX . "baiduid` ADD INDEX(`portrait`);", true);
+
+//update name_show and portrait
+$result = $m->query("SELECT bduss FROM ".DB_PREFIX."baiduid;");
+while ($row = $result->fetch_assoc()) {
+	$baiduUserInfo = getBaiduUserInfo($row["bduss"]);
+	if (!empty($baiduUserInfo["portrait"])) {
+		$baidu_name = sqladds($baiduUserInfo["name"]);
+		$baidu_name_portrait = sqladds($baiduUserInfo["portrait"]);
+		$m->query("UPDATE ".DB_PREFIX."baiduid SET `portrait` = '{$baidu_name_portrait}' WHERE `bduss` = '{$row["bduss"]}';");
+	}
+}
+
+option::set('core_version' , '4.97');
+unlink(__FILE__);
+msg('您的云签到已成功升级到 V4.97 版本，请立即删除 /setup/update4.96to4.97.php，谢谢', SYSTEM_URL);

--- a/templates/baiduid.php
+++ b/templates/baiduid.php
@@ -38,8 +38,9 @@ global $m;
   <thead>
     <tr>
       <th>PID</th>
-      <th style="width:25%">百度名称</th>
-      <th style="width:65%">BDUSS Cookie</th>
+      <th style="width:20%">百度名称</th>
+      <th style="width:20%">Portrait</th>
+      <th style="width:60%">BDUSS Cookie</th>
       <th>操作</th>
     </tr>
   </thead>
@@ -50,7 +51,7 @@ global $m;
       $name = empty($i['user']['baidu'][$key]) ? '未记录百度ID' : $i['user']['baidu'][$key];
       if($name == '[E]') $name='<font color="red">已失效</font>';
       //echo '<td><a href="setting.php?mod=baiduid&reget='.$key.'"">'.$name.'</a></td>';
-      echo '<td>'.$name.'</td>';
+      echo '<td>'.$name.'</td><td><input type="text" class="form-control" readonly value="'.$i['user']['baidu_portrait'][$key].'"></td>';
       echo '<td><input type="text" class="form-control" readonly value="'.$value.'"></td><td><a class="btn btn-default" href="setting.php?mod=baiduid&del='.$key.'">解绑</a></td></tr>';
     }
    ?>

--- a/templates/index.php
+++ b/templates/index.php
@@ -115,7 +115,7 @@ if (ROLE == 'admin') {
 			}
 			echo '</li>';
 			if (defined('ANTI_CSRF') && !ANTI_CSRF) {
-				echo '<li class="list-group-item"><font color="#FF6600"><span class="glyphicon glyphicon-warning-sign"></span> <b>安全性警告：</b></font>站点的<a href="http://github.com/MoeNetwork/Tieba-Cloud-Sign/wikis/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">CSRF防御</a>被关闭，站点有一定的安全风险。</li>';
+				echo '<li class="list-group-item"><font color="#FF6600"><span class="glyphicon glyphicon-warning-sign"></span> <b>安全性警告：</b></font>站点的<a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">CSRF防御</a>被关闭，站点有一定的安全风险。</li>';
 			}
 			if (version_compare(PHP_VERSION, '5.4.0') < 0) {
 				echo '<li class="list-group-item"><font color="#FF6600"><span class="glyphicon glyphicon-warning-sign"></span> <b>安全性警告：</b></font>站点使用的PHP版本较落后，云签到效率和安全水平下降。</li>';

--- a/templates/set.php
+++ b/templates/set.php
@@ -31,8 +31,8 @@ function addset($name,$type,$x,$other = '',$text = '') {
 		<tr>
 			<td>头像设置<br/>使用Gravatar头像或贴吧头像</td>
 			<td>
-				<input type="radio" name="face_img" value="0" <?php if (option::uget('face_img') == '0') { echo 'checked'; } ?>> 使用Gravatar头像<br/>
-				<input type="radio" name="face_img" value="1" <?php if (option::uget('face_img') == '1') { echo 'checked'; } ?>> 使用贴吧头像（推荐） 贴吧用户名：
+				<input type="radio" name="face_img" value="0" <?php if (option::uget('face_img') == '0') { echo 'checked'; } ?>> 使用Gravatar头像（推荐）<br/>
+				<input type="radio" name="face_img" value="1" <?php if (option::uget('face_img') == '1') { echo 'checked'; } ?>> 使用贴吧头像 贴吧用户名：
 				<input type="text" name="face_baiduid" value="<?php if (option::uget('face_baiduid')) { echo option::uget('face_baiduid'); } ?>" class="form-control" >
 			</td>
 		</tr>

--- a/templates/showtb.php
+++ b/templates/showtb.php
@@ -23,7 +23,7 @@ if (!empty($i['user']['bduss'])) {
 			$f[$x['pid']] = '';
 		}
 		$f[$x['pid']] .= '<tr><td>'.$x['id'].'</td>';
-		$f[$x['pid']] .= '<td class="wrap"><a title="'.$x['tieba'].'" href="http://tieba.baidu.com/f?ie=utf-8&kw='.$x['tieba'].'" target="_blank">'. mb_substr($x['tieba'] , 0 , 30 , 'UTF-8') .'</a>';
+		$f[$x['pid']] .= '<td class="wrap"><a title="'.$x['tieba'].'" href="https://tieba.baidu.com/f?ie=utf-8&kw='.$x['tieba'].'" target="_blank">'. mb_substr($x['tieba'] , 0 , 30 , 'UTF-8') .'</a>';
 		if ($x['status'] != 0) {
 			$count2++;
 			$f[$x['pid']] .= '<br/><b>错误:</b>' . $x['last_error'] . '</td>';
@@ -52,11 +52,11 @@ if (!empty($i['user']['bduss'])) {
 	if(!empty($f)) {
 		echo '<ul class="nav nav-tabs">';
 		foreach($i['user']['baidu'] as $pkey => $pval) {
-			echo '<li role="presentation" class="pidlist"><a data-toggle="tab" onclick="showtbpanel(\''.$pkey.'\');">'.$pval.'</a></li>';
+			echo '<li role="presentation" class="pidlist"><a data-toggle="tab" onclick="showtbpanel(\''.$pkey.'\');">'.($pval ?: $i['user']['baidu_portrait'][$pkey]).'</a></li>';
 		}
 		echo '</ul>';
 		echo '<form action="setting.php?mod=showtb&set" method="post">';
-		foreach($i['user']['baidu'] as $pkey => $pval) {
+		foreach($i['user']['baidu_portrait'] as $pkey => $pval) {
 			if(isset($f[$pkey])) {
 				echo '<div id="tbpidpanel_' . $pkey . '" class="tbpanel" style="display:none">';
 				echo '<div class="table-responsive"><table class="table table-hover"><thead><tr>';
@@ -93,7 +93,7 @@ if (!empty($i['user']['bduss'])) {
 						<span class="input-group-addon">请选择对应账号</span>
 						<select name="pid" required class="form-control">
 							<?php foreach ($i['user']['bduss'] as $key => $value) {
-								$name = empty($i['user']['baidu'][$key]) ? ' [未知]' : (' ('.$i['user']['baidu'][$key].')');
+								$name = empty($i['user']['baidu'][$key]) ? " [{$i['user']['baidu_portrait'][$key]}]" : (' ('.$i['user']['baidu'][$key] . " [{$i['user']['baidu_portrait'][$key]}]".')');
 								echo '<option value="'.$key.'">'.$key.$name.'</option>';
 							}
 							?>


### PR DESCRIPTION
feat: 使用 portrait 替代用户名
update: 使用函数 `addTiebaSign()` 生成 sign
update: 更新 wcurl 默认 user-agent
update: 推荐 PHP 版本从 5.4+ 到 7.4+ （但仍然支持PHP5.x）
add: 根据 portrait/百度id 获取帐号信息的函数 `getUserInfo()`
add: 通过 uid 生成旧版 portrait 的函数 `uid2LegacyPortrait()`
add: 一键迁移脚本 4.96 -> 4.97
fix: GitHub 的链接
fix: `misc::scanTiebaByPid` 中的死循环
fix: 根据百度id获取头像的功能