### PR TITLE
尝试修复 'CVE-2022-28920'

### DIFF
--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -1018,3 +1018,21 @@ function csrf($strict = true) {
 		if($p['host'] != (isset($parse_system_url['host']) ? $parse_system_url['host'] : '')) msg('CSRF防御：错误的请求来源<a href="https://github.com/MoeNetwork/Tieba-Cloud-Sign/wiki/%E5%85%B3%E4%BA%8E%E4%BA%91%E7%AD%BE%E5%88%B0CSRF%E9%98%B2%E5%BE%A1" target="_blank">了解更多关于CSRF防御...</a>');
 	}
 }
+
+/**
+ * 检查URL，防XSS
+ * @param string $url 待处理的url
+ * @param string $linktext 链接文字
+ * @return string 纯文本或者链接dom
+ */
+function sanitize_html_link($url = "", $linktext = "") {
+	if (!$url) {
+		htmlspecialchars($linktext ?: "");
+	}
+	$parseUrl = parse_url($url);
+	if (isset($parseUrl["scheme"]) && in_array($parseUrl["scheme"], ["http", "https"])) {
+		return '<a href="'.$url.'" target="_blank">' . htmlspecialchars($linktext ?: "") . '</a>';
+	} else {
+		htmlspecialchars($linktext ?: "");
+	}
+}

--- a/lib/ui.php
+++ b/lib/ui.php
@@ -52,22 +52,14 @@ function loadfoot($copy = false) {
             $plug = $i['plugins']['desc'][$copy];
             echo '<br/><br/>';
             if(!empty($plug['plugin']['url'])) {
-                echo '<a href="'.htmlspecialchars($plug['plugin']['url']).'" target="_blank">';
-            }
-            echo $plug[ 'plugin' ][ 'name' ];
-            if(!empty($plug['plugin']['url'])) {
-                echo '</a>';
+				echo sanitize_html_link($plug['plugin']['url'], $plug['plugin']['name']);
             }
             if(!empty($plug['plugin'][ 'version' ])) {
                 echo ' V'.$plug['plugin'][ 'version' ];
             }
             echo ' // 作者：';
             if(!empty($plug['author']['url'])) {
-                echo '<a href="'.htmlspecialchars($plug['author']['url']).'" target="_blank">';
-            }
-            echo $plug[ 'author' ][ 'author' ];
-            if(!empty($plug['author']['url'])) {
-                echo '</a>';
+				echo sanitize_html_link($plug['author']['url'], $plug['author']['author']);
             }
         }
     }

--- a/templates/admin-plugins.php
+++ b/templates/admin-plugins.php
@@ -16,7 +16,7 @@ foreach($x as $key => $val) {
 	$pluginfo = '';
 	$action   = '';
 	if (!empty($val['plugin']['url'])) {
-		$pluginfo .= '<b><a href="'.htmlspecialchars($val['plugin']['url']).'" target="_blank">'.$val['plugin']['name'].'</a></b>';
+		$pluginfo .= '<b>' . sanitize_html_link($val['plugin']['url'], $val['plugin']['name']) . '</b>';
 	} else {
 		$pluginfo .= '<b>'.$val['plugin']['name'].'</b>';
 	}
@@ -36,7 +36,7 @@ foreach($x as $key => $val) {
 	}
 
 	if (!empty($val['author']['url'])) {
-		$authinfo = '<a href="'.htmlspecialchars($val['author']['url']).'" target="_blank">'.$val['author']['author'].'</a>';
+		$authinfo = sanitize_html_link($val['author']['url'], $val['author']['author']);
 	} else {
 		$authinfo = $val['author']['author'];
 	}

--- a/templates/control.php
+++ b/templates/control.php
@@ -54,16 +54,14 @@ switch ($i['mode'][0]) {
 				$plug = strip_tags($_GET['plug']);
 				$pluginfo = getPluginInfo($plug);
 
-				if (file_exists(SYSTEM_ROOT.'/plugins/'.$plug.'/'.$plug.'_setting.php') && in_array($_GET['plug'], $i['plugins']['actived'])) {
+				if (file_exists(SYSTEM_ROOT.'/plugins/'.$plug.'/'.$plug.'_setting.php') && in_array($plug, $i['plugins']['actived'])) {
                     loadhead($pluginfo['plugin']['name'] . ' - 插件管理');
 					require_once SYSTEM_ROOT.'/plugins/'.$plug.'/'.$plug.'_setting.php';
                     echo '<br/><br/><br/>';
-                    if(!empty($pluginfo['plugin']['url']))
-                        echo '<a href="'.$pluginfo['plugin']['url'].'" target="_blank">';
-                    echo $pluginfo['plugin']['name'];
-                    if(!empty($pluginfo['plugin']['url']))
-                        echo '</a>';
-                    echo ' V'.$pluginfo['plugin']['version'].' // 插件作者：<a href="'.$pluginfo['author']['url'].'" target="_blank">'.$pluginfo['author']['author'].'</a><br/>'.SYSTEM_FN.' V'.SYSTEM_VER.' // 程序作者: <a href="https://kenvix.com" target="_blank">Kenvix</a>  &amp; <a href="http://www.mokeyjay.com/" target="_blank">mokeyjay</a> &amp;  <a href="http://fyy1999.lofter.com/" target="_blank">FYY</a> ';
+                    if(!empty($pluginfo['plugin']['url'])) {
+						echo sanitize_html_link($pluginfo['plugin']['url'], $pluginfo['plugin']['name']);
+					}
+                    echo ' V'.$pluginfo['plugin']['version'].' // 插件作者：' . sanitize_html_link($pluginfo['author']['url'], $pluginfo['author']['author']) . '<br/>'.SYSTEM_FN.' V'.SYSTEM_VER.' // 程序作者: <a href="https://kenvix.com" target="_blank">Kenvix</a>  &amp; <a href="http://www.mokeyjay.com/" target="_blank">mokeyjay</a> &amp;  <a href="http://fyy1999.lofter.com/" target="_blank">FYY</a> ';
 				} else {
 					echo '<b>插件设置页面不存在</b>';
 				}


### PR DESCRIPTION
引入新函数 `sanitize_html_link()` 处理外链的生成，将会检查传入链接的 `scheme`，目前允许的 `scheme` 包括 `http` 与 `https`，若链接不符合要求将只返回实体化特殊符号的纯文字
