### PR TITLE
紧急bug: 修复获取贴吧fid

### DIFF
--- a/lib/class.misc.php
+++ b/lib/class.misc.php
@@ -149,7 +149,7 @@ class misc
         } else {
             $ch = new wcurl('http://tieba.baidu.com/f/commit/share/fnameShareApi?ie=utf-8&fname=' . urlencode($kw), array('User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1','Referer: http://tieba.baidu.com/'));
             $r = json_decode($ch->exec(), true);
-            return $r['no'] === '0' ? $r['data']['fid'] : false;
+            return $r['no'] === 0 ? $r['data']['fid'] : false;
         }
     }
 


### PR DESCRIPTION
获取贴吧fid时,返回包json中,'no'键的值的类型为int

[https://github.com/MoeNetwork/Tieba-Cloud-Sign/blob/023316e0df05ddafd55060717f399d617854c618/lib/class.misc.php#L152](https://github.com/MoeNetwork/Tieba-Cloud-Sign/blob/023316e0df05ddafd55060717f399d617854c618/lib/class.misc.php#L152)

而代码中判断的时候将类型设为了str,最终会导致获取贴吧fid时永远为false(即永远获取不到贴吧fid),除非本身贴吧fid已经在数据库中存在了: 

[https://github.com/MoeNetwork/Tieba-Cloud-Sign/blob/023316e0df05ddafd55060717f399d617854c618/lib/class.misc.php#L146](https://github.com/MoeNetwork/Tieba-Cloud-Sign/blob/023316e0df05ddafd55060717f399d617854c618/lib/class.misc.php#L146)

我猜可能是百度贴吧更新了?
