### PR TITLE
需要设置关闭caddy admin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
     && echo -e "max_execution_time = 3600\nupload_max_filesize=128M\npost_max_size=128M\nmemory_limit=1024M\ndate.timezone=${TZ}" > /etc/php81/conf.d/99-overrides.ini \
     && echo -e "[global]\nerror_log = /dev/stdout\ndaemonize = no\ninclude=/etc/php81/php-fpm.d/*.conf" > /etc/php81/php-fpm.conf \
     && echo -e "[www]\nuser = caddy\ngroup = caddy\nlisten = 127.0.0.1:9000\nlisten.owner = caddy\nlisten.group = caddy\npm = ondemand\npm.max_children = 75\npm.max_requests = 500\npm.process_idle_timeout = 10s\nchdir = $WORKDIR" > /etc/php81/php-fpm.d/www.conf \
-    && echo -e ":8080\nroot * $WORKDIR\nlog {\n    level warn\n}\nphp_fastcgi 127.0.0.1:9000\nfile_server" > /etc/caddy/Caddyfile \
+    && echo -e "{\n    admin off\n}\n:8080\nroot * $WORKDIR\nlog {\n    level warn\n}\nphp_fastcgi 127.0.0.1:9000\nfile_server" > /etc/caddy/Caddyfile \
     && rm -rf $WORKDIR/* /var/cache/apk/* /tmp/* \
     && git config --global pull.ff only \
     && git clone --depth=1 -b master https://github.com/MoeNetwork/Tieba-Cloud-Sign $WORKDIR \


### PR DESCRIPTION
不关的话会一直弹0.0.0.0:2019已经被绑定，同时不会监听8080端口。