### PR TITLE
修改网站 密码 和 cookie 的散列计算方式

### DIFF
--- a/init.php
+++ b/init.php
@@ -6,7 +6,7 @@
  */
 
 define('SYSTEM_FN', '百度贴吧云签到');
-define('SYSTEM_VER', '5.00');
+define('SYSTEM_VER', '5.01');
 define('SYSTEM_VER_NOTE', '');
 define('SYSTEM_ROOT', dirname(__FILE__));
 define('PLUGIN_ROOT', dirname(__FILE__) . '/plugins/');

--- a/lib/globals.php
+++ b/lib/globals.php
@@ -13,7 +13,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
         $con_uid = isset($_COOKIE['uid']) ? sqladds($_COOKIE['con_uid']) : '';
         $con_pw  = isset($_COOKIE['pwd']) ? sqladds($_COOKIE['con_pwd']) : '';
         $con_p   = $m->once_fetch_array("SELECT * FROM  `" . DB_NAME . "`.`" . DB_PREFIX . "users` WHERE `id` = '{$con_uid}' LIMIT 1");
-        if (empty($con_p['id']) || !VerifyPwd($con_p['pw'], $con_pw)) {
+        if (empty($con_p['id']) || hash_hmac('sha256', $con_p['pw'], ($con_p['id'] % 1024) . $con_p['pw']) !== $con_pw) {
             setcookie("con_uid", '', time() - 3600);
             setcookie("con_pwd", '', time() - 3600);
         } else {
@@ -42,7 +42,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
     }
     doAction('globals_1');
     $p = $m->fetch_array($osq);
-    if (!VerifyPwd($p['pw'], $pw)) {
+    if (hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']) !== $pw) {
         setcookie("uid", '', time() - 3600);
         setcookie("pwd", '', time() - 3600);
         ReDirect("index.php?mod=login&error_msg=" . urlencode('Cookies 所记录的账号信息不正确，请重新登录(#2)') . "");
@@ -147,11 +147,11 @@ if (SYSTEM_PAGE == 'admin:login') {
                 $cktime = 999999;
             }
             setcookie("uid", $p['id'], time() + $cktime);
-            setcookie("pwd", EncodePwd($p['pw']), time() + $cktime);
+            setcookie("pwd", hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']), time() + $cktime);
             ReDirect('index.php');
         } else {
             setcookie("uid", $p['id']);
-            setcookie("pwd", EncodePwd($p['pw']));
+            setcookie("pwd", hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']));
             ReDirect('index.php');
         }
     }

--- a/lib/globals.php
+++ b/lib/globals.php
@@ -13,7 +13,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
         $con_uid = isset($_COOKIE['uid']) ? sqladds($_COOKIE['con_uid']) : '';
         $con_pw  = isset($_COOKIE['pwd']) ? sqladds($_COOKIE['con_pwd']) : '';
         $con_p   = $m->once_fetch_array("SELECT * FROM  `" . DB_NAME . "`.`" . DB_PREFIX . "users` WHERE `id` = '{$con_uid}' LIMIT 1");
-        if (empty($con_p['id']) || hash_hmac('sha256', $con_p['pw'], ($con_p['id'] % 1024) . $con_p['pw']) !== $con_pw) {
+        if (empty($con_p['id']) || hash_hmac('sha256', $con_p['pw'], $con_p['id'] . $con_p['pw']) !== $con_pw) {
             setcookie("con_uid", '', time() - 3600);
             setcookie("con_pwd", '', time() - 3600);
         } else {
@@ -42,7 +42,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
     }
     doAction('globals_1');
     $p = $m->fetch_array($osq);
-    if (hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']) !== $pw) {
+    if (hash_hmac('sha256', $p['pw'], $p['id'] . $p['pw']) !== $pw) {
         setcookie("uid", '', time() - 3600);
         setcookie("pwd", '', time() - 3600);
         ReDirect("index.php?mod=login&error_msg=" . urlencode('Cookies 所记录的账号信息不正确，请重新登录(#2)') . "");
@@ -147,11 +147,11 @@ if (SYSTEM_PAGE == 'admin:login') {
                 $cktime = 999999;
             }
             setcookie("uid", $p['id'], time() + $cktime);
-            setcookie("pwd", hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']), time() + $cktime);
+            setcookie("pwd", hash_hmac('sha256', $p['pw'], $p['id'] . $p['pw']), time() + $cktime);
             ReDirect('index.php');
         } else {
             setcookie("uid", $p['id']);
-            setcookie("pwd", hash_hmac('sha256', $p['pw'], ($p['id'] % 1024) . $p['pw']));
+            setcookie("pwd", hash_hmac('sha256', $p['pw'], $p['id'] . $p['pw']));
             ReDirect('index.php');
         }
     }

--- a/lib/globals.php
+++ b/lib/globals.php
@@ -13,7 +13,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
         $con_uid = isset($_COOKIE['uid']) ? sqladds($_COOKIE['con_uid']) : '';
         $con_pw  = isset($_COOKIE['pwd']) ? sqladds($_COOKIE['con_pwd']) : '';
         $con_p   = $m->once_fetch_array("SELECT * FROM  `" . DB_NAME . "`.`" . DB_PREFIX . "users` WHERE `id` = '{$con_uid}' LIMIT 1");
-        if (empty($con_p['id']) || $con_pw != substr(sha1(EncodePwd($con_p['pw'])), 4, 32)) {
+        if (empty($con_p['id']) || !VerifyPwd($con_p['pw'], $con_pw)) {
             setcookie("con_uid", '', time() - 3600);
             setcookie("con_pwd", '', time() - 3600);
         } else {
@@ -42,7 +42,7 @@ if (isset($_COOKIE['uid']) && isset($_COOKIE['pwd'])) {
     }
     doAction('globals_1');
     $p = $m->fetch_array($osq);
-    if ($pw != substr(sha1(EncodePwd($p['pw'])), 4, 32)) {
+    if (!VerifyPwd($p['pw'], $pw)) {
         setcookie("uid", '', time() - 3600);
         setcookie("pwd", '', time() - 3600);
         ReDirect("index.php?mod=login&error_msg=" . urlencode('Cookies 所记录的账号信息不正确，请重新登录(#2)') . "");
@@ -135,7 +135,7 @@ if (SYSTEM_PAGE == 'admin:login') {
             die;
     }
     $p = $m->fetch_array($osq);
-    if (EncodePwd($pw) != $p['pw']) {
+    if (!VerifyPwd($pw, $p['pw'])) {
         ReDirect("index.php?mod=login&error_msg=" . urlencode('密码错误'));
         die;
     } else {
@@ -147,11 +147,11 @@ if (SYSTEM_PAGE == 'admin:login') {
                 $cktime = 999999;
             }
             setcookie("uid", $p['id'], time() + $cktime);
-            setcookie("pwd", substr(sha1(EncodePwd(EncodePwd($pw))), 4, 32), time() + $cktime);
+            setcookie("pwd", EncodePwd($p['pw']), time() + $cktime);
             ReDirect('index.php');
         } else {
             setcookie("uid", $p['id']);
-            setcookie("pwd", substr(sha1(EncodePwd(EncodePwd($pw))), 4, 32));
+            setcookie("pwd", EncodePwd($p['pw']));
             ReDirect('index.php');
         }
     }

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -24,13 +24,25 @@ function getIp()
 /**
  * 加密密码
  * @param string $pwd 密码
- * @return string 加密的密码
+ * @param boolean $with_legacy 是否包含旧密码
+ * @return string|object 新密码和旧版密码
  */
-function EncodePwd($pwd)
+function EncodePwd($pwd, $with_legacy = false)
 {
-
     $p = new P();
-    return $p->pwd($pwd);
+    return $p->pwd($pwd, $with_legacy);
+}
+
+/**
+ * 校验密码
+ * @param string $pwd 密码
+ * @param string $hash hash 值
+ * @return boolean 新密码和旧版密码
+ */
+function VerifyPwd($pwd, $hash)
+{
+    $p = new P();
+    return $p->pwd_verify($pwd, $hash);
 }
 
 /**

--- a/lib/sfc.functions.php
+++ b/lib/sfc.functions.php
@@ -37,7 +37,7 @@ function EncodePwd($pwd, $with_legacy = false)
  * 校验密码
  * @param string $pwd 密码
  * @param string $hash hash 值
- * @return boolean 新密码和旧版密码
+ * @return boolean 密码是否合法
  */
 function VerifyPwd($pwd, $hash)
 {

--- a/setup/install.template.sql
+++ b/setup/install.template.sql
@@ -88,7 +88,7 @@ INSERT INTO `{VAR-PREFIX}options` VALUES ('cron_sign_again', 'a:2:{s:3:\"num\";i
 INSERT INTO `{VAR-PREFIX}options` VALUES ('sign_hour', '0');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('mail_secure', 'none');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('freetable', 'tieba');
-INSERT INTO `{VAR-PREFIX}options` VALUES ('core_version', '4.98');
+INSERT INTO `{VAR-PREFIX}options` VALUES ('core_version', '5.01');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('vid', '10000');
 INSERT INTO `{VAR-PREFIX}options` VALUES ('update_server', '0');
 #INSERT INTO `{VAR-PREFIX}options` VALUES ('toolpw', '{VAR-TOOLPW}');

--- a/setup/install.template.sql
+++ b/setup/install.template.sql
@@ -145,7 +145,7 @@ DROP TABLE IF EXISTS `{VAR-PREFIX}users`;
 CREATE TABLE `{VAR-PREFIX}users` (
   `id` int(30) NOT NULL AUTO_INCREMENT,
   `name` varchar(20) NOT NULL,
-  `pw` char(32) NOT NULL,
+  `pw` TEXT NOT NULL,
   `email` varchar(40) NOT NULL,
   `role` varchar(10) NOT NULL DEFAULT 'user',
   `t` varchar(20) NOT NULL DEFAULT 'tieba',

--- a/setup/update5.00to5.01.php
+++ b/setup/update5.00to5.01.php
@@ -1,0 +1,17 @@
+<?php
+
+define('SYSTEM_DEV', true);
+define('SYSTEM_NO_CHECK_VER', true);
+define('SYSTEM_NO_CHECK_LOGIN', true);
+define('SYSTEM_NO_PLUGIN', true);
+include __DIR__ . '/../init.php';
+global $m,$i;
+$cv = option::get('core_version');
+if (!empty($cv) && $cv >= '5.01') {
+    msg('您的云签到已升级到 V5.01 版本，请勿重复更新<br/><br/>请立即删除 /setup/update5.00to5.01.php');
+}
+$m->query("ALTER TABLE `" . DB_PREFIX . "users` CHANGE `pw` `pw` TEXT;", true);
+
+option::set('core_version', '5.01');
+unlink(__FILE__);
+msg('您的云签到已成功升级到 V5.01 版本，请立即删除 /setup/update5.00to5.01.php，谢谢', SYSTEM_URL);


### PR DESCRIPTION
### 修改

- 默认（`PHP >= 5.5.0`）使用 `password_hash()` + `PASSWORD_BCRYPT` 用以替代原有的 `md5(md5(md5($pwd)))` / 用户自定义计算方法，如果运行主机的 PHP 版本不支持的这个方法，将会回退到原有的方法
- 使用 `password_verify()`（`PHP >= 5.5.0`）校验用户登录时提交的密码，若不支持该方法同样会回退到原有方法计算并比较
- 使用 `hash_hmac` 计算密码哈希的 hmac-sha256 作为 cookie，密钥为 id 加上密码哈希本身，**由于我对加密了解不深，这样做是否妥当，有没有更好的方法还请在下方评论指出**
- 数据表 `tc_users` 中记录帐号密码的列 `pw` 的类型将会修改成 `TEXT` 以应对更长的密码哈希
- 除了会被踢下线以外，用户不会有任何影响

### 会有什么影响？

- 已登录的用户会被强制下线，因为 Cookie 会改变
- 在支持 `password_hash` 等方法的主机上
  - 新注册和修改密码的用户将会保存被 `password_hash()` 处理过的密码哈希
  - 没有进行密码修改的用户将会保持原样
- 不支持的设备上不会有任何变化
- 调用了 `EncodePwd()` 方法的插件需要调用 `VerifyPwd($pwd, $hash)` 校验哈希是否合法，而不再是重新生成一遍再比较是否相同，由于 Bcrypt 的耗时还是挺高的，可能需要考虑继续使用 `EncodePwd()` 还是换别的方法

### 其他

附带的那个 `update5.00to5.01.php` 请以最终版本号为准