### PR TITLE
修复更新Cookie加密算法后切换用户失效

### DIFF
--- a/setting.php
+++ b/setting.php
@@ -334,12 +334,12 @@ msg('<meta http-equiv="refresh" content="0; url=setting.php?mod=updatefid&step='
         break;
     case 'admin:users':
         if (!empty($_GET['control'])) {
-            $osq = $m->once_fetch_array("SELECT `role`,`pw` FROM  `" . DB_NAME . "`.`" . DB_PREFIX . "users` WHERE `id` = '{$_GET['control']}' LIMIT 1");
+            $osq = $m->once_fetch_array("SELECT `id`,`role`,`pw` FROM  `" . DB_NAME . "`.`" . DB_PREFIX . "users` WHERE `id` = '{$_GET['control']}' LIMIT 1");
             empty($osq['pw']) and msg('用户不存在');
             $osq['role'] == 'admin' and msg('无法控制管理员');
             doAction('admin_users_control');
             setcookie("uid", $_GET['control'], time() + 999999);
-            setcookie("pwd", substr(sha1(EncodePwd($osq['pw'])), 4, 32), time() + 999999);
+            setcookie("pwd", hash_hmac('sha256', $osq['pw'], $osq['id'] . $osq['pw']), time() + 999999);
             setcookie("con_uid", UID);
             setcookie("con_pwd", $_COOKIE['pwd']);
             redirect('index.php');


### PR DESCRIPTION
同步下#252 的加密算法更新