### PR TITLE
修复一些由 #273 引入的错误和兼容性问题

### DIFF
--- a/lib/class.mysql.php
+++ b/lib/class.mysql.php
@@ -48,14 +48,14 @@ class wmysql
         }
 
         $flag = 0;
-        if ($useSsl) {
+        if ($useSSL) {
             $flag = $flag & MYSQL_CLIENT_SSL;
         }
 
         if ($long) {
             $this->conn = @mysql_pconnect($host, $user, $pw, $flag);
         } else {
-            $this->conn = @mysql_connect($host, $user, $pw, client_flags: $flag);
+            $this->conn = @mysql_connect($host, $user, $pw, false, $flag);
         }
         if (!$this->conn) {
             switch ($this->geterrno()) {

--- a/lib/class.mysqli.php
+++ b/lib/class.mysqli.php
@@ -50,7 +50,7 @@ class wmysql
         
         $flags = 0;
         $mysqli = mysqli_init();
-        if ($useSsl) {
+        if ($useSSL) {
             $flags = $flags | MYSQLI_CLIENT_SSL;
         }
 
@@ -59,12 +59,12 @@ class wmysql
             if ($long) {
                 $host = 'p:' . $host;
             }
-            $connected = $mysqli->real_connect($host, $user, $pw, $name, flags: $flags);
+            $connected = $mysqli->real_connect($host, $user, $pw, $name, null, $flags);
         } else {
             if ($long) {
-                $connected = $mysqli->real_connect('p:' . substr($host, 0, $coninfo), $user, $pw, $name, substr($host, $coninfo + 1), flags: $flags);
+                $connected = $mysqli->real_connect('p:' . substr($host, 0, $coninfo), $user, $pw, $name, substr($host, $coninfo + 1), null, $flags);
             } else {
-                $connected = $mysqli->real_connect(substr($host, 0, $coninfo), $user, $pw, $name, substr($host, $coninfo + 1), flags: $flags);
+                $connected = $mysqli->real_connect(substr($host, 0, $coninfo), $user, $pw, $name, substr($host, $coninfo + 1), null, $flags);
             }
         }
         


### PR DESCRIPTION
- 修改 `wmysql` 中大小写错误的变量名 `$useSsl`
- 移除 `wmysql` 中出现的命名参数

  > 命名参数是 PHP 8.0.0 引入的，docker 用的版本是 8.1 没有问题，安装界面建议是 7.4 以上，根据以往 issue 实际使用中的可能还有一些 5.x 的版本，这些旧版本可能会不受支持

## 其他

尝试在新加坡区域的 TiDB Cloud 安装云签，每次都只能新建几个表，无法正常完成安装