### PR TITLE
(WIP) 讨论是否应该提高支持的 PHP 版本

### DIFF
--- a/setup/check.php
+++ b/setup/check.php
@@ -74,10 +74,10 @@ function checkclass($f, $m = false)
     </thead>
     <tbody>
         <tr>
-        <td><a href="http://php.net/" target="_blank">PHP 5+</a></td>
+        <td><a href="http://php.net/" target="_blank">PHP 8+</a></td>
             <td>必须</td>
             <td><?php echo phpversion(); ?></td>
-            <td>核心，未来云签到将不支持 PHP 7.4 以下版本，请尽快升级</td>
+            <td>核心，未来云签到将不兼容过旧的 PHP 版本，当前活跃的版本请查看 <a href="https://www.php.net/supported-versions.php" target="blank">Supported Versions</a></td>
         </tr>
         <tr>
             <td><a href="http://php.net/manual/zh/book.curl.php" target="_blank">Client URL</a></td>

--- a/setup/install.php
+++ b/setup/install.php
@@ -138,7 +138,6 @@ define(\'SYSTEM_SALT\',\'\');
                 echo '<div class="input-group"><span class="input-group-addon">数据库开启SSL</span><select name="dbssl" class="form-control" required="true"><option value="0">否</option><option value="1">是</option></select></div><br/>';
                 echo '<input type="hidden" name="isbae" value="1">';
                 echo '<input type="hidden" name="from_config" value="1">';
-                echo '<input type="hidden" name="dbssl" value="0">';
             } else {
                 echo '<br/><b>提示 1：</b>如果您已经手动写好了 config.php ，请选择 [ <b>自动获得数据库配置信息</b> ] 为 <b>是</b><br/>';
                 echo '<b>提示 2：</b>如果程序并未写入数据库 [ 安装完成后进入首页提示 Table XX doesn\'t exist  ] 请选择强制手动导入 SQL<br/><br/>';


### PR DESCRIPTION
从 #273 引申出来的问题

> docker 用的版本是 8.1，安装界面建议是 7.4 以上，根据以往 issue 实际使用中的可能还有一些 5.x 的版本

目前云签仍然在尝试 **兼容** 到 PHP 5.x，但实际上都是**凭空兼容**，本人已经很长时间没用过任何低于 PHP 8.0 的环境了，patch 打上去能不能运行全凭翻文档加想象，实际上能不能用，只能靠 issue 的反馈：没有 issue 那就算能跑

与其这样浪费精力在想象上面，不如放弃旧版的兼容，只考虑仍在维护的 PHP 版本（比如根据 [Supported Versions](https://www.php.net/supported-versions.php) 现在只需要兼容到 8.1）。这样并不意味着旧版 PHP 马上就不能使用，在未来的某次引入了新方法的提交以前，旧版 PHP 还是可以继续用的

### TL;DR

累了，不想浪费时间在旧版 PHP 了，如果通过本 pr 今后只考虑仍受 PHP 官方支持的 PHP 版本，否则继续通过**想象**维持着对旧版本的**兼容**