### PR TITLE
当 php 版本大于 8.0.0 时不再调用 `curl_close`

### DIFF
--- a/lib/class.wcurl.php
+++ b/lib/class.wcurl.php
@@ -264,7 +264,7 @@ class wcurl
     public function close()
     {
         // DEPRECATED since PHP 8.5.0
-        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+        if (PHP_VERSION_ID <= 80000) {
             @curl_close($this->conn);
         }
     }

--- a/lib/class.wcurl.php
+++ b/lib/class.wcurl.php
@@ -354,7 +354,7 @@ class wcurl
             curl_reset($this->conn);
         } else {
             if (is_resource($this->conn)) {
-                if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+                if (PHP_VERSION_ID <= 80000) {
                     curl_close($this->conn);
                 }
             }

--- a/lib/class.wcurl.php
+++ b/lib/class.wcurl.php
@@ -263,8 +263,10 @@ class wcurl
      */
     public function close()
     {
-
-        @curl_close($this->conn);
+        // DEPRECATED since PHP 8.5.0
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            @curl_close($this->conn);
+        }
     }
 
     /**
@@ -352,7 +354,9 @@ class wcurl
             curl_reset($this->conn);
         } else {
             if (is_resource($this->conn)) {
-                curl_close($this->conn);
+                if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+                    curl_close($this->conn);
+                }
             }
             $this->conn = curl_init();
         }


### PR DESCRIPTION
FYI: <https://www.php.net/manual/zh/function.curl-close.php>

> 8.5.0 | 此函数已被弃用。-> 会开始抛出警告
> 8.0.0 | 此函数现在是 NOP（空操作）。

虽然 `8.0.0` 也应该包含在内，但当时忘了，不太重要就这样吧
