### PR TITLE
提高安全性

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -123,18 +123,24 @@ switch (SYSTEM_PAGE) {
         if (!file_exists(UPDATE_CACHE)) {
             mkdir(UPDATE_CACHE, 0777, true);
         }
-        $commit_mode = isset($_GET["commit"]) && $_GET["commit"];
+        $commit_mode = isset($_POST["commit"]) && $_POST["commit"];
+        $floderName = UPDATE_FNAME_GITHUB;
         //下载zip包
         //switch (option::get('update_server')){
         //  //OSCGIT禁止了直接下载
         //  //CODING仓库都没了
         //  default:
         if ($commit_mode) {
-            $c = new wcurl("https://github.com/MoeNetwork/Tieba-Cloud-Sign/archive/{$_GET["commit"]}.zip");
+            $commit_id = strtolower(trim($_POST["commit"]));
+            if (preg_match('/^[0-9a-f]{40}$/i', $commit_id) !== 1) {
+                DeleteFile(UPDATE_CACHE);
+                msg('错误 - 更新失败：<br/><br/>无效的 commit id');
+            }
+            $c = new wcurl("https://github.com/MoeNetwork/Tieba-Cloud-Sign/archive/{$commit_id}.zip");
+            $floderName = 'Tieba-Cloud-Sign-' . $commit_id;
         } else {
             $c = new wcurl(UPDATE_SERVER_GITHUB);
         }
-        $floderName = $commit_mode ? 'Tieba-Cloud-Sign-' . $_GET["commit"] : UPDATE_FNAME_GITHUB;
         //      break;
         //}
         $file = $c->exec();

--- a/ajax.php
+++ b/ajax.php
@@ -123,7 +123,7 @@ switch (SYSTEM_PAGE) {
         if (!file_exists(UPDATE_CACHE)) {
             mkdir(UPDATE_CACHE, 0777, true);
         }
-        $commit_mode = isset($_POST["commit"]) && $_POST["commit"];
+        $commit_mode = isset($_POST["commit"]) && $_POST["commit"] && SYSTEM_DEV;
         $floderName = UPDATE_FNAME_GITHUB;
         //下载zip包
         //switch (option::get('update_server')){

--- a/templates/admin-update.php
+++ b/templates/admin-update.php
@@ -45,7 +45,7 @@ doAction('admin_update_1');
 <?php
 //检测服务器是否支持写入
 if (is_writable("setup")) {
-    echo '<div id="comsys2">
+    ?><div id="comsys2">
 	<div class="alert alert-info"><span id="upd_info">正在检查更新......</span><br/><br/>
 	<div class="progress progress-striped active">
 	<div class="progress-bar progress-bar-success" id="upd_prog" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 30%">
@@ -56,8 +56,7 @@ if (is_writable("setup")) {
 <div id="comsys2"></div>
 <div id="comsys3"></div>
 <div id="comsys4">
-  <form action="ajax.php" method="get">
-    <input type="hidden" name="mod" value="admin:update:updnow">
+  <form action="ajax.php?mod=admin:update:updnow" method="post">
     <div class="input-group">
       <span class="input-group-addon">输入 commit id</span>
       <input type="text" class="form-control" name="commit" id="commit_input">
@@ -76,8 +75,8 @@ if (is_writable("setup")) {
 	  4.输入框可填写commit id，提交后将下载任意未删除的commit的文件。<span class="text-danger">注意：来自非官方仓库的 commit (包括 pull requests 中的提交) 的安全性并不可靠，请不要在生产环境下使用此类方式更新。</span>
     </div>
   </div>
-</div>';
-    $writable = "1";
+</div>
+  <?php $writable = "1";
 } else {
     echo '<div class="alert alert-danger" role="alert">你的服务器不支持文件写入，请手动更新</div>';
     $writable = "0";

--- a/templates/admin-update.php
+++ b/templates/admin-update.php
@@ -55,6 +55,7 @@ if (is_writable("setup")) {
 <div id="comsys"></div>
 <div id="comsys2"></div>
 <div id="comsys3"></div>
+<?php if (SYSTEM_DEV) {?>
 <div id="comsys4">
   <form action="ajax.php?mod=admin:update:updnow" method="post">
     <div class="input-group">
@@ -64,6 +65,7 @@ if (is_writable("setup")) {
     </div>
   </form>
 </div>
+<?php }?>
 <br>
 <div id="comsys5">
   <div class="panel panel-default" style="background-color: #F9F9F9;">
@@ -72,7 +74,9 @@ if (is_writable("setup")) {
 	  1.commit模式会使用最新commit，但不是所有commit都安全可用，建议等待一段时间再更新。<br/>
 	  2.任何时候都能检查到最新commit，即使云签已经是最新版本。<br/>
 	  3.部分版本变动需要执行升级脚本，请留意相关提示；若没有提示可能是因为更新前后跨越的版本较大，请前往<a href="./setup/update.php" target="_blank">脚本列表</a>查看。<br>
-	  4.输入框可填写commit id，提交后将下载任意未删除的commit的文件。<span class="text-danger">注意：来自非官方仓库的 commit (包括 pull requests 中的提交) 的安全性并不可靠，请不要在生产环境下使用此类方式更新。</span>
+    <?php if (SYSTEM_DEV) {?>
+	  4.输入框可填写commit id，提交后将下载任意未删除的commit的文件。<span class="text-danger">注意：来自非官方仓库的 commit (包括 pull requests 中的提交) 的安全性并不可靠，生产环境禁止使用此方式更新。</span>
+    <?php }?>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- 只允许在开发者模式下使用指定 commit id 更新
- 更新 commit id 的提交方式 GET->POST
- 验证 commit id 格式，禁止使用短位 id